### PR TITLE
Log out the deadline for when a server is supposed to stop.

### DIFF
--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -68,18 +68,20 @@ module Sidekiq
       sleep PAUSE_TIME
       return if @workers.empty?
 
-      logger.info { "Pausing to allow workers to finish by #{deadline}..." }
-      remaining = deadline - ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      clock_time = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      logger.info { "Pausing to allow workers to finish by #{deadline}... time is #{clock_time}" }
+      remaining = deadline - clock_time
       num_sleep = 0
       while remaining > PAUSE_TIME
         return if @workers.empty?
         sleep PAUSE_TIME
         num_sleep += 1
-        remaining = deadline - ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+        clock_time = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+        remaining = deadline - clock_time
 
         # Log out every 30s how much time is left in the deadline
         if (num_sleep * PAUSE_TIME) % 30 == 0
-          logger.info { "Remaining time left to finish is #{remaining}..." }
+          logger.info { "Remaining time left to finish is #{remaining}, clock time is #{clock_time}..." }
         end
       end
       return if @workers.empty?

--- a/lib/sidekiq/manager.rb
+++ b/lib/sidekiq/manager.rb
@@ -68,12 +68,19 @@ module Sidekiq
       sleep PAUSE_TIME
       return if @workers.empty?
 
-      logger.info { "Pausing to allow workers to finish..." }
+      logger.info { "Pausing to allow workers to finish by #{deadline}..." }
       remaining = deadline - ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      num_sleep = 0
       while remaining > PAUSE_TIME
         return if @workers.empty?
         sleep PAUSE_TIME
+        num_sleep += 1
         remaining = deadline - ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+
+        # Log out every 30s how much time is left in the deadline
+        if (num_sleep * PAUSE_TIME) % 30 == 0
+          logger.info { "Remaining time left to finish is #{remaining}..." }
+        end
       end
       return if @workers.empty?
 


### PR DESCRIPTION
Am trying to track down why some servers don't appear to be hard shutting down. E.g., https://my.papertrailapp.com/groups/182591/events?focus=1394506271281008646&q=w-msg-i-022a049f3a66752c1.production-east-1.appboy.com was shutting down for an hour before AWS killed it.