### PR TITLE
Add RedisConnectionPool class to intercept and modify exceptions

### DIFF
--- a/lib/sidekiq/redis_connection.rb
+++ b/lib/sidekiq/redis_connection.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "connection_pool"
+require "sidekiq/redis_connection_pool"
 require "redis"
 require "uri"
 
@@ -31,7 +31,9 @@ module Sidekiq
         pool_timeout = symbolized_options[:pool_timeout] || 1
         log_info(symbolized_options)
 
-        ConnectionPool.new(timeout: pool_timeout, size: size) do
+        # BRAZE MODIFIED CODE
+        # this swaps ConnectionPool for RedisConnectionPool and provides name/url as arguments
+        Sidekiq::RedisConnectionPool.new("sidekiq_shards", symbolized_options[:url], timeout: pool_timeout, size: size) do
           build_client(symbolized_options)
         end
       end

--- a/lib/sidekiq/redis_connection_pool.rb
+++ b/lib/sidekiq/redis_connection_pool.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "connection_pool"
+require "redis"
+
+module Sidekiq
+  # This is a Braze-added class that will annotate exceptions with the name/url of the redis instance that the exception
+  # occured with.
+  class RedisConnectionPool < ConnectionPool
+    # We override #initialize so that we can assign a name and URL to the ConnectionPool. That way, if we have
+    # connection errors, we can roll them up by name/location.
+    def initialize(name, url, options = {}, &block)
+      super(options, &block)
+      @name = name
+      @url = url
+    end
+
+    # We override #with so that we can catch connection-related errors.
+    def with(options = {})
+      super
+    rescue Redis::BaseConnectionError, Timeout::Error => e
+      begin
+        e.instance_variable_set(:@redis_url, @url)
+        e.instance_variable_set(:@redis_type, @name)
+      rescue
+        # ignored
+      end
+      raise e
+    end
+  end
+end


### PR DESCRIPTION
This allows us to utilize the name and url of the shard in error
reporting and things when Redis is the underlying cause of an exception
in the sidekiq library.